### PR TITLE
Fix(build_dataset): Data construction failed due to DataFrameGroupBy.apply

### DIFF
--- a/build_dataset/build_dataset_amazon.py
+++ b/build_dataset/build_dataset_amazon.py
@@ -85,9 +85,10 @@ print(f"After activity filtering: {len(df):,} interactions, {df['user_id'].nuniq
 
 # ── Cap each user at 85 most-recent interactions ─────────────────────────────
 df = (
-    df.groupby('user_id', group_keys=False)
-    .apply(lambda x: x.nlargest(85, 'timestamp') if len(x) > 85 else x)
-    .reset_index(drop=True)
+    df.sort_values(['user_id', 'timestamp'], ascending=[True, False])
+      .groupby('user_id', as_index=False)
+      .head(85)
+      .reset_index(drop=True)
 )
 df = df.rename(columns={'user_id': 'user', 'parent_asin': 'ItemID'})
 

--- a/build_dataset/build_dataset_yelp.py
+++ b/build_dataset/build_dataset_yelp.py
@@ -104,8 +104,11 @@ print(f"After activity filtering: {len(reviews_filtered):,} reviews, "
 # ── Cap each user at 75 most-recent reviews ──────────────────────────────────
 reviews_filtered['date'] = pd.to_datetime(reviews_filtered['date'])
 df = (
-    reviews_filtered.groupby('user_id', group_keys=False)
-    .apply(lambda x: x.sort_values('date').tail(75) if len(x) > 75 else x)
+    reviews_filtered
+    .sort_values(['user_id', 'date'], ascending=[True, False])
+    .groupby('user_id', as_index=False)
+    .head(75)
+    .sort_values(['user_id', 'date'], ascending=[True, True])
     .reset_index(drop=True)
 )
 


### PR DESCRIPTION
This is an excellent piece of work. However, when I attempted to build the data by running `python build_dataset/build_dataset_amazon.py` and `python build_dataset/build_dataset_yelp.py`, I encountered some problems.

Due to the fact that the function `DataFrameGroupBy.apply` in `pandas>=3.0` excludes the grouping column (namely, `user_id`) from the sub-DataFrame passed to the function `apply`, this results in an error like:

```
Traceback (most recent call last):
  File "/mnt/sdc/user_workspace/chenjiawei/shared/Dont-Start-Over/build_dataset/build_dataset_amazon.py", line 97, in <module>
    train_df, valid_df = train_valid_split(df)
                         ^^^^^^^^^^^^^^^^^^^^^
  File "/mnt/sdc/user_workspace/chenjiawei/shared/Dont-Start-Over/build_dataset/build_dataset_amazon.py", line 53, in train_valid_split
    for _, user_df in df.groupby('user'):
                      ^^^^^^^^^^^^^^^^^^
  File "/home/chenjiawei/miniconda3/envs/dso/lib/python3.12/site-packages/pandas/util/_decorators.py", line 336, in wrapper
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/chenjiawei/miniconda3/envs/dso/lib/python3.12/site-packages/pandas/core/frame.py", line 10817, in groupby
    return DataFrameGroupBy(
           ^^^^^^^^^^^^^^^^^
  File "/home/chenjiawei/miniconda3/envs/dso/lib/python3.12/site-packages/pandas/core/groupby/groupby.py", line 1095, in __init__
    grouper, exclusions, obj = get_grouper(
                               ^^^^^^^^^^^^
  File "/home/chenjiawei/miniconda3/envs/dso/lib/python3.12/site-packages/pandas/core/groupby/grouper.py", line 901, in get_grouper
    raise KeyError(gpr)
KeyError: 'user'
```

Therefore, I changed the implementation method, so that the script can run successfully in `pandas>=3.0`.